### PR TITLE
Prevent model invalidation after sent email

### DIFF
--- a/BtcTransmuter.Extension.Email/ExternalServices/Smtp/SmtpController.cs
+++ b/BtcTransmuter.Extension.Email/ExternalServices/Smtp/SmtpController.cs
@@ -51,7 +51,6 @@ namespace BtcTransmuter.Extension.Email.ExternalServices.Smtp
                 var error = await SendTestEmail(smtpService, viewModel.TestEmail);
                 if (string.IsNullOrEmpty(error))
                 {
-                    ModelState.AddModelError(nameof(viewModel.TestEmail), "Email sent successfully, confirm that you received it");
                     viewModel.TestEmail = string.Empty;
                 }
                 else


### PR DESCRIPTION
Removed the confirmation message as it invalidates the model, preventing it from being saved. Shouldn't be an error msg, right?